### PR TITLE
Add Makefile for project setup and management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Makefile for Company Research Agent
+
+# Variables
+PYTHON=python3
+PIP=pip
+UV=uv
+VENV=.venv
+BACKEND_PORT=8000
+FRONTEND_DIR=ui
+
+# Detect if uv is available
+UV_EXISTS := $(shell command -v uv 2> /dev/null)
+
+.PHONY: setup backend frontend dev clean
+
+setup:
+	@if [ -n "$(UV_EXISTS)" ]; then \
+		echo "[+] Using uv for Python setup..."; \
+		$(UV) venv $(VENV); \
+		source $(VENV)/bin/activate && $(UV) pip install -r requirements.txt; \
+	else \
+		echo "[+] Using pip for Python setup..."; \
+		$(PYTHON) -m venv $(VENV); \
+		source $(VENV)/bin/activate && $(PIP) install -r requirements.txt; \
+	fi
+	cd $(FRONTEND_DIR) && npm install
+
+backend:
+	@echo "[+] Starting backend (FastAPI with Uvicorn)..."
+	. $(VENV)/bin/activate && uvicorn application:app --reload --port $(BACKEND_PORT)
+
+frontend:
+	@echo "[+] Starting frontend (Vite dev server)..."
+	cd $(FRONTEND_DIR) && npm run dev
+
+dev:
+	@echo "[+] Starting backend and frontend (dev mode)..."
+	@echo "[!] You will need two terminals for interactive logs."
+	@echo "[+] Run 'make backend' in one terminal and 'make frontend' in another."
+
+clean:
+	@echo "[+] Cleaning up virtual environment and node_modules..."
+	rm -rf $(VENV)
+	cd $(FRONTEND_DIR) && rm -rf node_modules

--- a/README.es.md
+++ b/README.es.md
@@ -160,6 +160,7 @@ Necesitarás tener listas las siguientes claves API:
 - Clave API de Tavily
 - Clave API de Google Gemini
 - Clave API de OpenAI
+- Clave API de Google Maps
 - URI de MongoDB (opcional)
 
 ### Instalación Manual
@@ -197,7 +198,14 @@ cd ui
 npm install
 ```
 
-4. Crear un archivo `.env` con tus claves API:
+4. **Configurar Variables de Entorno**:
+
+Este proyecto requiere dos archivos `.env` separados para el backend y el frontend.
+
+**Configuración del Backend:**
+
+Crea un archivo `.env` en el directorio raíz del proyecto y añade tus claves API del backend:
+
 ```env
 TAVILY_API_KEY=tu_clave_tavily
 GEMINI_API_KEY=tu_clave_gemini
@@ -205,6 +213,22 @@ OPENAI_API_KEY=tu_clave_openai
 
 # Opcional: Habilitar persistencia en MongoDB
 # MONGODB_URI=tu_cadena_de_conexion_mongodb
+```
+
+**Configuración del Frontend:**
+
+Crea un archivo `.env` dentro del directorio `ui`. Puedes copiar primero el archivo de ejemplo:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Luego, abre `ui/.env` y añade tus variables de entorno del frontend:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=tu_clave_google_maps_aqui
 ```
 
 ### Instalación con Docker
@@ -217,7 +241,14 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. Crear un archivo `.env` con tus claves API:
+2. **Configurar Variables de Entorno**:
+
+La configuración de Docker utiliza dos archivos `.env` separados.
+
+**Configuración del Backend:**
+
+Crea un archivo `.env` en el directorio raíz del proyecto con tus claves API del backend:
+
 ```env
 TAVILY_API_KEY=tu_clave_tavily
 GEMINI_API_KEY=tu_clave_gemini
@@ -225,6 +256,22 @@ OPENAI_API_KEY=tu_clave_openai
 
 # Opcional: Habilitar persistencia en MongoDB
 # MONGODB_URI=tu_cadena_de_conexion_mongodb
+```
+
+**Configuración del Frontend:**
+
+Crea un archivo `.env` dentro del directorio `ui`. Puedes copiar primero el archivo de ejemplo:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Luego, abre `ui/.env` y añade tus variables de entorno del frontend:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=tu_clave_google_maps_aqui
 ```
 
 3. Construir e iniciar los contenedores:

--- a/README.es.md
+++ b/README.es.md
@@ -20,7 +20,7 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 - **Investigación Multi-Fuente**: Recopila datos de diversas fuentes, incluyendo sitios web de empresas, artículos de noticias, informes financieros y análisis sectoriales
 - **Filtrado de Contenido Impulsado por IA**: Utiliza la puntuación de relevancia de Tavily para la selección de contenido
 - **Transmisión de Progreso en Tiempo Real**: Utiliza conexiones WebSocket para transmitir el progreso de la investigación y los resultados
-- **Arquitectura de Modelo Dual**: 
+- **Arquitectura de Modelo Dual**:
   - Gemini 2.0 Flash para síntesis de investigación de alto contexto
   - GPT-4.1 para formato preciso y edición de informes
 - **Frontend Moderno en React**: Interfaz de usuario receptiva con actualizaciones en tiempo real, seguimiento de progreso y opciones de descarga
@@ -127,7 +127,7 @@ La plataforma implementa un sistema de comunicación en tiempo real basado en We
 
 ### Instalación Rápida (Recomendada)
 
-La forma más sencilla de comenzar es utilizando el script de instalación:
+La forma más sencilla de comenzar es utilizando el script de instalación, que detecta automáticamente y usa `uv` para una instalación más rápida de paquetes Python cuando está disponible:
 
 1. Clonar el repositorio:
 ```bash
@@ -142,11 +142,19 @@ chmod +x setup.sh
 ```
 
 El script de instalación hará lo siguiente:
+
+- Detectar y usar `uv` para una instalación más rápida de paquetes Python (si está disponible)
 - Verificar las versiones requeridas de Python y Node.js
 - Opcionalmente crear un entorno virtual de Python (recomendado)
 - Instalar todas las dependencias (Python y Node.js)
 - Guiarte a través de la configuración de tus variables de entorno
 - Opcionalmente iniciar los servidores de backend y frontend
+
+> **💡 Consejo Pro**: Instala [uv](https://github.com/astral-sh/uv) para una instalación significativamente más rápida de paquetes Python:
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 Necesitarás tener listas las siguientes claves API:
 - Clave API de Tavily
@@ -167,11 +175,20 @@ cd tavily-company-research
 2. Instalar dependencias de backend:
 ```bash
 # Opcional: Crear y activar entorno virtual
-python -m venv .venv
+# Con uv (más rápido - recomendado si está disponible):
+uv venv .venv
 source .venv/bin/activate
 
+# O con Python estándar:
+# python -m venv .venv
+# source .venv/bin/activate
+
 # Instalar dependencias de Python
-pip install -r requirements.txt
+# Con uv (más rápido):
+uv pip install -r requirements.txt
+
+# O con pip:
+# pip install -r requirements.txt
 ```
 
 3. Instalar dependencias de frontend:
@@ -262,7 +279,10 @@ npm run dev
    **Opción 2: FastAPI con Uvicorn**
    ```bash
    # Instalar uvicorn si aún no está instalado
-   pip install uvicorn
+   # Con uv (más rápido):
+   uv pip install uvicorn
+   # O con pip:
+   # pip install uvicorn
 
    # Ejecutar la aplicación FastAPI con recarga automática
    uvicorn application:app --reload --port 8000
@@ -279,6 +299,8 @@ npm run dev
    ```
 
 3. Acceder a la aplicación en `http://localhost:5173`
+
+> **⚡ Nota de Rendimiento**: Si usaste `uv` durante la instalación, te beneficiarás de una instalación de paquetes y resolución de dependencias significativamente más rápida. `uv` es un gestor de paquetes Python moderno escrito en Rust que puede ser 10-100x más rápido que pip.
 
 ### Opciones de Despliegue
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -128,7 +128,7 @@ La plateforme implémente un système de communication en temps réel basé sur 
 
 ### Configuration Rapide (Recommandée)
 
-La façon la plus simple de commencer est d'utiliser le script de configuration :
+La façon la plus simple de commencer est d'utiliser le script de configuration, qui détecte automatiquement et utilise `uv` pour une installation plus rapide des paquets Python lorsqu'il est disponible :
 
 1. Clonez le dépôt :
 ```bash
@@ -143,13 +143,22 @@ chmod +x setup.sh
 ```
 
 Le script de configuration va :
+
+- Détecter et utiliser `uv` pour une installation plus rapide des paquets Python (si disponible)
 - Vérifier les versions requises de Python et Node.js
 - Créer éventuellement un environnement virtuel Python (recommandé)
 - Installer toutes les dépendances (Python et Node.js)
 - Vous guider dans la configuration de vos variables d'environnement
 - Démarrer éventuellement les serveurs backend et frontend
 
+> **💡 Conseil Pro** : Installez [uv](https://github.com/astral-sh/uv) pour une installation significativement plus rapide des paquets Python :
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
+
 Vous aurez besoin des clés API suivantes :
+
 - Clé API Tavily
 - Clé API Google Gemini
 - Clé API OpenAI
@@ -160,28 +169,41 @@ Vous aurez besoin des clés API suivantes :
 Si vous préférez configurer manuellement, suivez ces étapes :
 
 1. Clonez le dépôt :
+
 ```bash
 git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
 2. Installez les dépendances backend :
+
 ```bash
 # Optionnel : Créez et activez un environnement virtuel
-python -m venv .venv
+# Avec uv (plus rapide - recommandé si disponible) :
+uv venv .venv
 source .venv/bin/activate
 
+# Ou avec Python standard :
+# python -m venv .venv
+# source .venv/bin/activate
+
 # Installez les dépendances Python
-pip install -r requirements.txt
+# Avec uv (plus rapide) :
+uv pip install -r requirements.txt
+
+# Ou avec pip :
+# pip install -r requirements.txt
 ```
 
 3. Installez les dépendances frontend :
+
 ```bash
 cd ui
 npm install
 ```
 
 4. Créez un fichier `.env` avec vos clés API :
+
 ```env
 TAVILY_API_KEY=votre_clé_tavily
 GEMINI_API_KEY=votre_clé_gemini
@@ -196,12 +218,14 @@ OPENAI_API_KEY=votre_clé_openai
 L'application peut être exécutée à l'aide de Docker et Docker Compose :
 
 1. Clonez le dépôt :
+
 ```bash
 git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
 2. Créez un fichier `.env` avec vos clés API :
+
 ```env
 TAVILY_API_KEY=votre_clé_tavily
 GEMINI_API_KEY=votre_clé_gemini
@@ -212,20 +236,24 @@ OPENAI_API_KEY=votre_clé_openai
 ```
 
 3. Construisez et démarrez les conteneurs :
+
 ```bash
 docker compose up --build
 ```
 
 Cela démarrera les services backend et frontend :
+
 - L'API backend sera disponible sur `http://localhost:8000`
 - Le frontend sera disponible sur `http://localhost:5174`
 
 Pour arrêter les services :
+
 ```bash
 docker compose down
 ```
 
 Remarque : Lors de la mise à jour des variables d'environnement dans `.env`, vous devrez redémarrer les conteneurs :
+
 ```bash
 docker compose down && docker compose up
 ```
@@ -233,6 +261,7 @@ docker compose down && docker compose up
 ### Exécution de l'Application
 
 1. Démarrez le serveur backend (choisissez une option) :
+
 ```bash
 # Option 1 : Module Python Direct
 python -m application.py
@@ -242,6 +271,7 @@ uvicorn application:app --reload --port 8000
 ```
 
 2. Dans un nouveau terminal, démarrez le frontend :
+
 ```bash
 cd ui
 npm run dev
@@ -256,14 +286,19 @@ npm run dev
 1. Démarrez le serveur backend (choisissez une option) :
 
    **Option 1 : Module Python Direct**
+
    ```bash
    python -m application.py
    ```
 
    **Option 2 : FastAPI avec Uvicorn**
+
    ```bash
    # Installez uvicorn si ce n'est pas déjà fait
-   pip install uvicorn
+   # Avec uv (plus rapide) :
+   uv pip install uvicorn
+   # Ou avec pip :
+   # pip install uvicorn
 
    # Exécutez l'application FastAPI avec rechargement à chaud
    uvicorn application:app --reload --port 8000
@@ -274,12 +309,15 @@ npm run dev
    - Point d'accès WebSocket : `ws://localhost:8000/research/ws/{job_id}`
 
 2. Démarrez le serveur de développement frontend :
+
    ```bash
    cd ui
    npm run dev
    ```
 
 3. Accédez à l'application sur `http://localhost:5173`
+
+> **⚡ Note de Performance** : Si vous avez utilisé `uv` lors de l'installation, vous bénéficierez d'une installation de paquets et d'une résolution de dépendances significativement plus rapides. `uv` est un gestionnaire de paquets Python moderne écrit en Rust qui peut être 10 à 100 fois plus rapide que pip.
 
 ### Options de Déploiement
 
@@ -288,41 +326,17 @@ L'application peut être déployée sur diverses plateformes cloud. Voici quelqu
 #### AWS Elastic Beanstalk
 
 1. Installez l'EB CLI :
+
    ```bash
    pip install awsebcli
    ```
 
 2. Initialisez l'application EB :
+
    ```bash
    eb init -p python-3.11 tavily-research
    ```
 
 3. Créez et déployez :
-   ```bash
-   eb create tavily-research-prod
+
    ```
-
-#### Autres Options de Déploiement
-
-- **Docker** : L'application inclut un Dockerfile pour le déploiement conteneurisé
-- **Heroku** : Déployez directement depuis GitHub avec le buildpack Python
-- **Google Cloud Run** : Adapté au déploiement conteneurisé avec mise à l'échelle automatique
-
-Choisissez la plateforme qui convient le mieux à vos besoins. L'application est indépendante de la plateforme et peut être hébergée partout où les applications web Python sont prises en charge.
-
-## Contribution
-
-1. Forkez le dépôt
-2. Créez une branche de fonctionnalité (`git checkout -b fonctionnalite/superbe-fonction`)
-3. Validez vos modifications (`git commit -m 'Ajout d'une superbe fonction'`)
-4. Poussez vers la branche (`git push origin fonctionnalite/superbe-fonction`)
-5. Ouvrez une Pull Request
-
-## Licence
-
-Ce projet est sous licence MIT - voir le fichier [LICENSE](LICENSE) pour plus de détails.
-
-## Remerciements
-
-- [Tavily](https://tavily.com/) pour l'API de recherche
-- Toutes les autres bibliothèques open-source et leurs contributeurs

--- a/README.fr.md
+++ b/README.fr.md
@@ -162,6 +162,7 @@ Vous aurez besoin des clés API suivantes :
 - Clé API Tavily
 - Clé API Google Gemini
 - Clé API OpenAI
+- Clé API Google Maps
 - URI MongoDB (optionnel)
 
 ### Configuration Manuelle
@@ -202,7 +203,13 @@ cd ui
 npm install
 ```
 
-4. Créez un fichier `.env` avec vos clés API :
+4. **Configuration des Variables d'Environnement** :
+
+Ce projet nécessite deux fichiers `.env` séparés pour le backend et le frontend.
+
+**Configuration Backend :**
+
+Créez un fichier `.env` dans le répertoire racine du projet et ajoutez vos clés API backend :
 
 ```env
 TAVILY_API_KEY=votre_clé_tavily
@@ -211,6 +218,22 @@ OPENAI_API_KEY=votre_clé_openai
 
 # Optionnel : Activez la persistance MongoDB
 # MONGODB_URI=votre_chaîne_de_connexion_mongodb
+```
+
+**Configuration Frontend :**
+
+Créez un fichier `.env` dans le répertoire `ui`. Vous pouvez d'abord copier le fichier d'exemple :
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Puis, ouvrez `ui/.env` et ajoutez vos variables d'environnement frontend :
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=votre_clé_google_maps_ici
 ```
 
 ### Configuration Docker
@@ -224,7 +247,13 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. Créez un fichier `.env` avec vos clés API :
+2. **Configuration des Variables d'Environnement** :
+
+La configuration Docker utilise deux fichiers `.env` séparés.
+
+**Configuration Backend :**
+
+Créez un fichier `.env` dans le répertoire racine du projet et ajoutez vos clés API backend :
 
 ```env
 TAVILY_API_KEY=votre_clé_tavily
@@ -233,6 +262,22 @@ OPENAI_API_KEY=votre_clé_openai
 
 # Optionnel : Activez la persistance MongoDB
 # MONGODB_URI=votre_chaîne_de_connexion_mongodb
+```
+
+**Configuration Frontend :**
+
+Créez un fichier `.env` dans le répertoire `ui`. Vous pouvez d'abord copier le fichier d'exemple :
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Puis, ouvrez `ui/.env` et ajoutez vos variables d'environnement frontend :
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=votre_clé_google_maps_ici
 ```
 
 3. Construisez et démarrez les conteneurs :

--- a/README.jp.md
+++ b/README.jp.md
@@ -161,6 +161,7 @@ chmod +x setup.sh
 - Tavily APIキー
 - Google Gemini APIキー
 - OpenAI APIキー
+- Google Maps APIキー
 - MongoDB URI（オプション）
 
 ### 手動セットアップ
@@ -198,7 +199,14 @@ cd ui
 npm install
 ```
 
-4. APIキーを含む`.env`ファイルを作成：
+4. **環境変数の設定**：
+
+このプロジェクトはバックエンドとフロントエンド用に2つの個別の`.env`ファイルが必要です。
+
+**バックエンド設定：**
+
+プロジェクトのルートディレクトリに`.env`ファイルを作成し、バックエンドAPIキーを追加します：
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -206,6 +214,22 @@ OPENAI_API_KEY=your_openai_key
 
 # オプション：MongoDB永続化を有効化
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**フロントエンド設定：**
+
+`ui`ディレクトリ内に`.env`ファイルを作成します。最初にサンプルファイルをコピーできます：
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+次に、`ui/.env`を開いてフロントエンド環境変数を追加します：
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 ### Dockerセットアップ
@@ -218,7 +242,14 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. APIキーを含む`.env`ファイルを作成：
+2. **環境変数の設定**：
+
+Docker設定は2つの個別の`.env`ファイルを使用します。
+
+**バックエンド設定：**
+
+プロジェクトのルートディレクトリに`.env`ファイルを作成し、バックエンドAPIキーを追加します：
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -226,6 +257,22 @@ OPENAI_API_KEY=your_openai_key
 
 # オプション：MongoDB永続化を有効化
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**フロントエンド設定：**
+
+`ui`ディレクトリ内に`.env`ファイルを作成します。最初にサンプルファイルをコピーできます：
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+次に、`ui/.env`を開いてフロントエンド環境変数を追加します：
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 3. コンテナをビルド・起動：

--- a/README.jp.md
+++ b/README.jp.md
@@ -128,7 +128,7 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 
 ### クイックセットアップ（推奨）
 
-最も簡単な開始方法はセットアップスクリプトを使用することです：
+最も簡単な開始方法はセットアップスクリプトを使用することです。このスクリプトは自動的に`uv`を検出し、利用可能な場合はより高速なPythonパッケージインストールに使用します：
 
 1. リポジトリをクローン：
 ```bash
@@ -143,11 +143,19 @@ chmod +x setup.sh
 ```
 
 セットアップスクリプトは以下を行います：
+
+- `uv`を検出してより高速なPythonパッケージインストールに使用（利用可能な場合）
 - 必要なPythonとNode.jsのバージョンを確認
 - Python仮想環境を作成（推奨）
 - すべての依存関係をインストール（PythonとNode.js）
 - 環境変数の設定をガイド
 - バックエンドとフロントエンドサーバーを起動（オプション）
+
+> **💡 プロのヒント**: [uv](https://github.com/astral-sh/uv)をインストールすることで、Pythonパッケージの大幅に高速なインストールが可能になります：
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 以下のAPIキーが必要です：
 - Tavily APIキー
@@ -168,11 +176,20 @@ cd tavily-company-research
 2. バックエンド依存関係をインストール：
 ```bash
 # オプション：仮想環境を作成・アクティベート
-python -m venv .venv
+# uv使用（より高速 - 利用可能な場合は推奨）：
+uv venv .venv
 source .venv/bin/activate
 
+# または標準Python：
+# python -m venv .venv
+# source .venv/bin/activate
+
 # Python依存関係をインストール
-pip install -r requirements.txt
+# uv使用（より高速）：
+uv pip install -r requirements.txt
+
+# またはpip使用：
+# pip install -r requirements.txt
 ```
 
 3. フロントエンド依存関係をインストール：
@@ -263,7 +280,10 @@ npm run dev
    **オプション2：UvicornでFastAPI**
    ```bash
    # uvicornがインストールされていない場合はインストール
-   pip install uvicorn
+   # uv使用（より高速）：
+   uv pip install uvicorn
+   # またはpip使用：
+   # pip install uvicorn
 
    # ホットリロード付きでFastAPIアプリケーションを実行
    uvicorn application:app --reload --port 8000
@@ -280,6 +300,8 @@ npm run dev
    ```
 
 3. `http://localhost:5173`でアプリケーションにアクセス
+
+> **⚡ パフォーマンス注意**: セットアップ時に`uv`を使用した場合、大幅に高速なパッケージインストールと依存関係解決の恩恵を受けられます。`uv`はRustで書かれた現代的なPythonパッケージマネージャーで、pipより10〜100倍高速です。
 
 ### デプロイメントオプション
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -161,6 +161,7 @@ chmod +x setup.sh
 - Tavily API 키
 - Google Gemini API 키
 - OpenAI API 키
+- Google Maps API 키
 - MongoDB URI (선택사항)
 
 ### 수동 설정
@@ -198,7 +199,14 @@ cd ui
 npm install
 ```
 
-4. API 키가 포함된 `.env` 파일 생성:
+4. **환경 변수 설정**:
+
+이 프로젝트는 백엔드와 프론트엔드용으로 두 개의 별도 `.env` 파일이 필요합니다.
+
+**백엔드 설정:**
+
+프로젝트 루트 디렉토리에 `.env` 파일을 생성하고 백엔드 API 키를 추가합니다:
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -206,6 +214,22 @@ OPENAI_API_KEY=your_openai_key
 
 # 선택사항: MongoDB 지속성 활성화
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**프론트엔드 설정:**
+
+`ui` 디렉토리 내에 `.env` 파일을 생성합니다. 먼저 예제 파일을 복사할 수 있습니다:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+그런 다음, `ui/.env`를 열고 프론트엔드 환경 변수를 추가합니다:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 ### Docker 설정
@@ -218,7 +242,14 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. API 키가 포함된 `.env` 파일 생성:
+2. **환경 변수 설정**:
+
+Docker 설정은 두 개의 별도 `.env` 파일을 사용합니다.
+
+**백엔드 설정:**
+
+프로젝트 루트 디렉토리에 `.env` 파일을 생성하고 백엔드 API 키를 추가합니다:
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -226,6 +257,22 @@ OPENAI_API_KEY=your_openai_key
 
 # 선택사항: MongoDB 지속성 활성화
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**프론트엔드 설정:**
+
+`ui` 디렉토리 내에 `.env` 파일을 생성합니다. 먼저 예제 파일을 복사할 수 있습니다:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+그런 다음, `ui/.env`를 열고 프론트엔드 환경 변수를 추가합니다:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 3. 컨테이너 빌드 및 시작:

--- a/README.kr.md
+++ b/README.kr.md
@@ -128,7 +128,7 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 
 ### 빠른 설정 (권장)
 
-시작하는 가장 쉬운 방법은 설정 스크립트를 사용하는 것입니다:
+시작하는 가장 쉬운 방법은 설정 스크립트를 사용하는 것입니다. 이 스크립트는 자동으로 `uv`를 감지하고 사용 가능할 때 더 빠른 Python 패키지 설치에 사용합니다:
 
 1. 저장소 클론:
 ```bash
@@ -143,11 +143,19 @@ chmod +x setup.sh
 ```
 
 설정 스크립트는 다음을 수행합니다:
+
+- `uv`를 감지하고 더 빠른 Python 패키지 설치에 사용 (사용 가능한 경우)
 - 필요한 Python 및 Node.js 버전 확인
 - Python 가상 환경 생성 (권장)
 - 모든 종속성 설치 (Python 및 Node.js)
 - 환경 변수 설정 안내
 - 백엔드 및 프론트엔드 서버 시작 (선택사항)
+
+> **💡 프로 팁**: [uv](https://github.com/astral-sh/uv)를 설치하여 훨씬 빠른 Python 패키지 설치를 이용하세요:
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 다음 API 키가 필요합니다:
 - Tavily API 키
@@ -168,11 +176,20 @@ cd tavily-company-research
 2. 백엔드 종속성 설치:
 ```bash
 # 선택사항: 가상 환경 생성 및 활성화
-python -m venv .venv
+# uv 사용 (더 빠름 - 사용 가능한 경우 권장):
+uv venv .venv
 source .venv/bin/activate
 
+# 또는 표준 Python:
+# python -m venv .venv
+# source .venv/bin/activate
+
 # Python 종속성 설치
-pip install -r requirements.txt
+# uv 사용 (더 빠름):
+uv pip install -r requirements.txt
+
+# 또는 pip 사용:
+# pip install -r requirements.txt
 ```
 
 3. 프론트엔드 종속성 설치:
@@ -249,6 +266,8 @@ npm run dev
 
 3. `http://localhost:5173`에서 애플리케이션에 액세스
 
+> **⚡ 성능 참고사항**: 설정 중에 `uv`를 사용했다면 훨씬 빠른 패키지 설치와 종속성 해결의 이점을 얻을 수 있습니다. `uv`는 Rust로 작성된 현대적인 Python 패키지 관리자로 pip보다 10-100배 빠를 수 있습니다.
+
 ## 사용법
 
 ### 로컬 개발
@@ -263,7 +282,10 @@ npm run dev
    **옵션 2: Uvicorn으로 FastAPI**
    ```bash
    # uvicorn이 설치되지 않은 경우 설치
-   pip install uvicorn
+   # uv 사용 (더 빠름):
+   uv pip install uvicorn
+   # 또는 pip 사용:
+   # pip install uvicorn
 
    # 핫 리로드로 FastAPI 애플리케이션 실행
    uvicorn application:app --reload --port 8000

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You'll need the following API keys ready:
 - Tavily API Key
 - Google Gemini API Key
 - OpenAI API Key
+- Google Maps API Key
 - MongoDB URI (optional)
 
 ### Manual Setup
@@ -198,7 +199,14 @@ cd ui
 npm install
 ```
 
-4. Create a `.env` file with your API keys:
+4. **Set up Environment Variables**:
+
+This project requires two separate `.env` files for the backend and frontend.
+
+**For the Backend:**
+
+Create a `.env` file in the project's root directory and add your backend API keys:
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -206,6 +214,22 @@ OPENAI_API_KEY=your_openai_key
 
 # Optional: Enable MongoDB persistence
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**For the Frontend:**
+
+Create a `.env` file inside the `ui` directory. You can copy the example file first:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Then, open `ui/.env` and add your frontend environment variables:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 ### Docker Setup
@@ -218,7 +242,14 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. Create a `.env` file with your API keys:
+2. **Set up Environment Variables**:
+
+The Docker setup uses two separate `.env` files.
+
+**For the Backend:**
+
+Create a `.env` file in the project's root directory with your backend API keys:
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -226,6 +257,22 @@ OPENAI_API_KEY=your_openai_key
 
 # Optional: Enable MongoDB persistence
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**For the Frontend:**
+
+Create a `.env` file inside the `ui` directory. You can copy the example file first:
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+Then, open `ui/.env` and add your frontend environment variables:
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 3. Build and start the containers:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/0e373146-26a7-4391-b973-224ded3182a9
 - **Multi-Source Research**: Gathers data from various sources including company websites, news articles, financial reports, and industry analyses
 - **AI-Powered Content Filtering**: Uses Tavily's relevance scoring for content curation
 - **Real-Time Progress Streaming**: Uses WebSocket connections to stream research progress and results
-- **Dual Model Architecture**: 
+- **Dual Model Architecture**:
   - Gemini 2.0 Flash for high-context research synthesis
   - GPT-4.1 for precise report formatting and editing
 - **Modern React Frontend**: Responsive UI with real-time updates, progress tracking, and download options
@@ -128,7 +128,7 @@ The platform implements a WebSocket-based real-time communication system:
 
 ### Quick Setup (Recommended)
 
-The easiest way to get started is using the setup script:
+The easiest way to get started is using the setup script, which automatically detects and uses `uv` for faster Python package installation when available:
 
 1. Clone the repository:
 ```bash
@@ -143,11 +143,19 @@ chmod +x setup.sh
 ```
 
 The setup script will:
+
+- Detect and use `uv` for faster Python package installation (if available)
 - Check for required Python and Node.js versions
 - Optionally create a Python virtual environment (recommended)
 - Install all dependencies (Python and Node.js)
 - Guide you through setting up your environment variables
 - Optionally start both backend and frontend servers
+
+> **💡 Pro Tip**: Install [uv](https://github.com/astral-sh/uv) for significantly faster Python package installation:
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 You'll need the following API keys ready:
 - Tavily API Key
@@ -168,11 +176,20 @@ cd tavily-company-research
 2. Install backend dependencies:
 ```bash
 # Optional: Create and activate virtual environment
-python -m venv .venv
+# With uv (faster - recommended if available):
+uv venv .venv
 source .venv/bin/activate
 
+# Or with standard Python:
+# python -m venv .venv
+# source .venv/bin/activate
+
 # Install Python dependencies
-pip install -r requirements.txt
+# With uv (faster):
+uv pip install -r requirements.txt
+
+# Or with pip:
+# pip install -r requirements.txt
 ```
 
 3. Install frontend dependencies:
@@ -263,7 +280,10 @@ npm run dev
    **Option 2: FastAPI with Uvicorn**
    ```bash
    # Install uvicorn if not already installed
-   pip install uvicorn
+   # With uv (faster):
+   uv pip install uvicorn
+   # Or with pip:
+   # pip install uvicorn
 
    # Run the FastAPI application with hot reload
    uvicorn application:app --reload --port 8000
@@ -280,6 +300,8 @@ npm run dev
    ```
 
 3. Access the application at `http://localhost:5173`
+
+> **⚡ Performance Note**: If you used `uv` during setup, you'll benefit from significantly faster package installation and dependency resolution. `uv` is a modern Python package manager written in Rust that can be 10-100x faster than pip.
 
 ### Deployment Options
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -128,7 +128,7 @@ https://github.com/user-attachments/assets/071aa491-009b-4d76-a698-88863149e71c
 
 ### 快速安装（推荐）
 
-最简单的方法是使用安装脚本：
+最简单的方法是使用安装脚本，它会自动检测并使用 `uv` 来实现更快的 Python 包安装（如果可用）：
 
 1. 克隆仓库：
 ```bash
@@ -143,11 +143,19 @@ chmod +x setup.sh
 ```
 
 安装脚本将：
+
+- 检测并使用 `uv` 进行更快的 Python 包安装（如果可用）
 - 检查所需的Python和Node.js版本
 - 可选创建Python虚拟环境（推荐）
 - 安装所有依赖（Python和Node.js）
 - 指导您设置环境变量
 - 可选启动后端和前端服务器
+
+> **💡 专业提示**: 安装 [uv](https://github.com/astral-sh/uv) 以获得显著更快的 Python 包安装：
+>
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 您需要准备以下API密钥：
 - Tavily API密钥
@@ -168,11 +176,20 @@ cd tavily-company-research
 2. 安装后端依赖：
 ```bash
 # 可选：创建并激活虚拟环境
-python -m venv .venv
+# 使用 uv（更快 - 如果可用则推荐）：
+uv venv .venv
 source .venv/bin/activate
 
-# 安装Python依赖
-pip install -r requirements.txt
+# 或使用标准 Python：
+# python -m venv .venv
+# source .venv/bin/activate
+
+# 安装 Python 依赖
+# 使用 uv（更快）：
+uv pip install -r requirements.txt
+
+# 或使用 pip：
+# pip install -r requirements.txt
 ```
 
 3. 安装前端依赖：
@@ -249,6 +266,8 @@ npm run dev
 
 3. 在`http://localhost:5173`访问应用程序
 
+> **⚡ 性能说明**: 如果您在设置过程中使用了 `uv`，您将受益于显著更快的包安装和依赖解析。`uv` 是一个用 Rust 编写的现代 Python 包管理器，比 pip 快 10-100 倍。
+
 ## 使用方法
 
 ### 本地开发
@@ -263,7 +282,10 @@ npm run dev
    **选项2：使用Uvicorn的FastAPI**
    ```bash
    # 如果尚未安装，安装uvicorn
-   pip install uvicorn
+   # 使用 uv（更快）：
+   uv pip install uvicorn
+   # 或使用 pip：
+   # pip install uvicorn
 
    # 使用热重载运行FastAPI应用
    uvicorn application:app --reload --port 8000
@@ -325,4 +347,4 @@ npm run dev
 ## 致谢
 
 - [Tavily](https://tavily.com/)提供研究API
-- 所有其他开源库及其贡献者 
+- 所有其他开源库及其贡献者

--- a/README.zh.md
+++ b/README.zh.md
@@ -161,6 +161,7 @@ chmod +x setup.sh
 - Tavily API密钥
 - Google Gemini API密钥
 - OpenAI API密钥
+- Google Maps API密钥
 - MongoDB URI（可选）
 
 ### 手动安装
@@ -198,7 +199,14 @@ cd ui
 npm install
 ```
 
-4. 创建包含API密钥的`.env`文件：
+4. **设置环境变量**：
+
+此项目需要两个单独的 `.env` 文件用于后端和前端。
+
+**后端配置：**
+
+在项目根目录创建 `.env` 文件并添加您的后端API密钥：
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -206,6 +214,22 @@ OPENAI_API_KEY=your_openai_key
 
 # 可选：启用MongoDB持久化
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**前端配置：**
+
+在 `ui` 目录内创建 `.env` 文件。您可以先复制示例文件：
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+然后，打开 `ui/.env` 并添加您的前端环境变量：
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 ### Docker安装
@@ -218,7 +242,14 @@ git clone https://github.com/pogjester/tavily-company-research.git
 cd tavily-company-research
 ```
 
-2. 创建包含API密钥的`.env`文件：
+2. **设置环境变量**：
+
+Docker 设置使用两个单独的 `.env` 文件。
+
+**后端配置：**
+
+在项目根目录创建 `.env` 文件并添加您的后端API密钥：
+
 ```env
 TAVILY_API_KEY=your_tavily_key
 GEMINI_API_KEY=your_gemini_key
@@ -226,6 +257,22 @@ OPENAI_API_KEY=your_openai_key
 
 # 可选：启用MongoDB持久化
 # MONGODB_URI=your_mongodb_connection_string
+```
+
+**前端配置：**
+
+在 `ui` 目录内创建 `.env` 文件。您可以先复制示例文件：
+
+```bash
+cp ui/.env.development.example ui/.env
+```
+
+然后，打开 `ui/.env` 并添加您的前端环境变量：
+
+```env
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 ```
 
 3. 构建并启动容器：

--- a/ui/.env.development.example
+++ b/ui/.env.development.example
@@ -1,2 +1,3 @@
 VITE_API_URL=http://localhost:8000
 VITE_WS_URL=ws://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here


### PR DESCRIPTION
Introduced a Makefile to streamline the setup and management of the Company Research Agent project. The Makefile includes targets for setting up a Python virtual environment with uv or pip, starting the backend with FastAPI and Uvicorn, launching the frontend with Vite, and cleaning up the environment. This addition enhances the development workflow by providing clear commands for common tasks.